### PR TITLE
Fix/init layer list

### DIFF
--- a/qmapcompare.py
+++ b/qmapcompare.py
@@ -85,4 +85,4 @@ class QMapCompare:
             self.dockwidget.hide()
         else:
             self.dockwidget.show()
-            self.iface.addDockWidget(Qt.RightDockWidgetArea, self.dockwidget)
+            self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.dockwidget)


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #18 

### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- Try to reload or reinstall plugin
- Plugin should appears with layer list
- (UI default position has been changed to left side as default to prepare Mirror compare mode)

<img width="1667" alt="image" src="https://github.com/user-attachments/assets/a46e5088-cf8b-45a0-bf99-810113f57a67" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- インターフェースのパネル位置が右側から左側に変更されました。
	- 起動時にパネルが自動的にコンテンツを読み込み、表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->