### PR TITLE
Hide Mirror widget close button

### DIFF
--- a/comparator/process.py
+++ b/comparator/process.py
@@ -209,7 +209,15 @@ def compare_with_mapview(compare_layers: list) -> None:
 
     map_widgets = get_map_dockwidgets()
     mirror_widget = map_widgets[0]
-    mirror_widget.parent().parent().parent().setWindowTitle(mirror_widget_name)
+
+    # Configure Mirror Dock Widget window
+    mirror_dock_widget = mirror_widget.parent().parent().parent()
+    mirror_dock_widget.setWindowTitle(mirror_widget_name)
+
+    # Hide close button to avoid bug when closing mirror window
+    features = mirror_dock_widget.features()
+    features = features & ~QDockWidget.DockWidgetClosable
+    mirror_dock_widget.setFeatures(features)
 
     # Add Map themes
     mapThemesCollection = QgsProject.instance().mapThemeCollection()


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #26 

### What I did（変更内容）
- Hide mirror compare dock widget close button ☒
- Try to compare in mirror mode, and close button should not appear
- We can close it only by clicking on Stop button or another compare mode

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/0a91cd28-af04-4d62-b75c-320ebb57dfc9" />

