### PR TITLE
Fix/close compare on new project

### DIFF
--- a/comparator/process.py
+++ b/comparator/process.py
@@ -242,7 +242,8 @@ def compare_with_mapview(compare_layers: list) -> None:
                 main_window.tabifyDockWidget(base_dock, right_dock_widgets[i])
 
         # add mirror map at last to be active
-        main_window.tabifyDockWidget(base_dock, mirror_dock_widget)
+        if mirror_dock_widget:
+            main_window.tabifyDockWidget(base_dock, mirror_dock_widget)
 
     else:
         # Case of if there is no other panel in right side

--- a/comparator/process.py
+++ b/comparator/process.py
@@ -33,7 +33,8 @@ from .utils import (
     get_visible_layers,
     toggle_layers,
     get_map_dockwidgets,
-    get_right_dockwidgets
+    get_right_dockwidgets,
+    set_panel_width
 )
 
 # Syncronize flag to avoid recursive map sync and crash
@@ -222,17 +223,31 @@ def compare_with_mapview(compare_layers: list) -> None:
 
     # Tabify right panels layouts Tabify with other Docks in right side
     right_dock_widgets = get_right_dockwidgets()
+
+    # Calculate size of tabified docks to be half of window
+    if len(right_dock_widgets) > 0:
+        max_width = max(dw.geometry().width() for dw in right_dock_widgets)
+    else:
+        max_width = 0
+    compare_map_size = (iface.mapCanvas().size().width() + max_width) / 2
+
     # Do only if there are more than 1 dock widget (1 is mirror compare map panel)
     if len(right_dock_widgets) > 1:
         base_dock = right_dock_widgets[0]  # the one to tabify the others onto
         for i in range(1, len(right_dock_widgets)):
             if right_dock_widgets[i].windowTitle() == mirror_widget_name:
-                # get index of Mirror Map to put at last
-                mirror_map_index = i
+                mirror_dock_widget = right_dock_widgets[i]
+                set_panel_width(mirror_dock_widget, compare_map_size)
             else:
                 main_window.tabifyDockWidget(base_dock, right_dock_widgets[i])
+                
         # add mirror map at last to be active
-        main_window.tabifyDockWidget(base_dock, right_dock_widgets[mirror_map_index])
+        main_window.tabifyDockWidget(base_dock, mirror_dock_widget)
+    
+    else:
+        # Case of if there is no other panel in right side
+        set_panel_width(right_dock_widgets[0], compare_map_size)
+        mirror_widget.refresh()
 
     # Add Map themes
     mapThemesCollection = QgsProject.instance().mapThemeCollection()

--- a/comparator/process.py
+++ b/comparator/process.py
@@ -34,7 +34,7 @@ from .utils import (
     toggle_layers,
     get_map_dockwidgets,
     get_right_dockwidgets,
-    set_panel_width
+    set_panel_width,
 )
 
 # Syncronize flag to avoid recursive map sync and crash
@@ -240,10 +240,10 @@ def compare_with_mapview(compare_layers: list) -> None:
                 set_panel_width(mirror_dock_widget, compare_map_size)
             else:
                 main_window.tabifyDockWidget(base_dock, right_dock_widgets[i])
-                
+
         # add mirror map at last to be active
         main_window.tabifyDockWidget(base_dock, mirror_dock_widget)
-    
+
     else:
         # Case of if there is no other panel in right side
         set_panel_width(right_dock_widgets[0], compare_map_size)

--- a/comparator/process.py
+++ b/comparator/process.py
@@ -33,6 +33,7 @@ from .utils import (
     get_visible_layers,
     toggle_layers,
     get_map_dockwidgets,
+    get_right_dockwidgets
 )
 
 # Syncronize flag to avoid recursive map sync and crash
@@ -218,6 +219,20 @@ def compare_with_mapview(compare_layers: list) -> None:
     mirror_dock_widget.setFeatures(
         QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetMovable
     )
+
+    # Tabify right panels layouts Tabify with other Docks in right side
+    right_dock_widgets = get_right_dockwidgets()
+    # Do only if there are more than 1 dock widget (1 is mirror compare map panel)
+    if len(right_dock_widgets) > 1:
+        base_dock = right_dock_widgets[0]  # the one to tabify the others onto
+        for i in range(1, len(right_dock_widgets)):
+            if right_dock_widgets[i].windowTitle() == mirror_widget_name:
+                # get index of Mirror Map to put at last
+                mirror_map_index = i
+            else:
+                main_window.tabifyDockWidget(base_dock, right_dock_widgets[i])
+        # add mirror map at last to be active
+        main_window.tabifyDockWidget(base_dock, right_dock_widgets[mirror_map_index])
 
     # Add Map themes
     mapThemesCollection = QgsProject.instance().mapThemeCollection()

--- a/comparator/utils.py
+++ b/comparator/utils.py
@@ -83,7 +83,7 @@ def get_map_dockwidgets() -> list:
     return map_widgets
 
 
-def get_right_dockwidgets():
+def get_right_dockwidgets() -> list:
     """Get visible dockwidgets located in right side of QGIS window"""
     main_window = iface.mainWindow()
 
@@ -95,3 +95,14 @@ def get_right_dockwidgets():
             right_dock_widgets.append(dock)
             
     return right_dock_widgets
+
+
+def set_panel_width(widget: QDockWidget, size: int) -> None:
+    """Set panel width, and allow afterhand size edit"""
+    widget.setFixedWidth(size)
+
+    # Remove fix width to allow width to be editable
+    widget.setMinimumWidth(100)  
+    widget.setMaximumWidth(10000) 
+
+    return

--- a/comparator/utils.py
+++ b/comparator/utils.py
@@ -10,6 +10,7 @@ from qgis.gui import QgsMapCanvas
 
 from qgis.PyQt.QtWidgets import QDockWidget
 from qgis.utils import iface
+from qgis.PyQt.QtCore import Qt
 
 from .constants import lens_auto_refresh_interval_time
 
@@ -80,3 +81,17 @@ def get_map_dockwidgets() -> list:
         if dock.findChild(QgsMapCanvas):
             map_widgets.append(dock.findChild(QgsMapCanvas))
     return map_widgets
+
+
+def get_right_dockwidgets():
+    """Get visible dockwidgets located in right side of QGIS window"""
+    main_window = iface.mainWindow()
+
+    right_dock_widgets = []
+    for dock in main_window.findChildren(QDockWidget):
+        # Check which side (dock area) the widget is in
+        dock_area = main_window.dockWidgetArea(dock)
+        if dock_area == Qt.RightDockWidgetArea and dock.isVisible():
+            right_dock_widgets.append(dock)
+            
+    return right_dock_widgets

--- a/comparator/utils.py
+++ b/comparator/utils.py
@@ -93,7 +93,7 @@ def get_right_dockwidgets() -> list:
         dock_area = main_window.dockWidgetArea(dock)
         if dock_area == Qt.RightDockWidgetArea and dock.isVisible():
             right_dock_widgets.append(dock)
-            
+
     return right_dock_widgets
 
 
@@ -102,7 +102,7 @@ def set_panel_width(widget: QDockWidget, size: int) -> None:
     widget.setFixedWidth(size)
 
     # Remove fix width to allow width to be editable
-    widget.setMinimumWidth(100)  
-    widget.setMaximumWidth(10000) 
+    widget.setMinimumWidth(100)
+    widget.setMaximumWidth(10000)
 
     return

--- a/qmapcompare_dockwidget.py
+++ b/qmapcompare_dockwidget.py
@@ -72,6 +72,9 @@ class QMapCompareDockWidget(QDockWidget):
         # flag current process to avoid recusrsive process bugs
         self.is_processing = False
 
+        # Stop compare mode when project is reinitialized
+        QgsProject.instance().cleared.connect(self._on_pushbutton_stopcompare_clicked)
+
     def _on_pushbutton_h_split_clicked(self):
         # get layers
         layers = self._get_checked_layers()


### PR DESCRIPTION
## Warning

Check PR #34 Before

<!-- Close or Related Issues -->
Close #35

### Test
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->
1. Reproduce error
- Switch to `main` branch
- Open a QGIS project
- Compare which some mode
- Open a new project or an existing project
- Compare still enabled

![image](https://github.com/user-attachments/assets/ce0dccfd-0673-4e95-888b-a95b9cd410b8)


2. Check fix 
- Switch to `fix/close-compare-on-new-project` branch
- Open a QGIS project
- Compare which some mode
- Open a new project or an existing project
- Compare should NOT be enabled
