### PR TITLE
Support Qt6

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install poetry
+      - name: Install uv
         run: python -m pip install uv
 
       - uses: actions/setup-python@v4

--- a/comparator/process.py
+++ b/comparator/process.py
@@ -1,42 +1,33 @@
-from qgis.core import (
-    QgsProject,
-    QgsLayerTreeGroup,
-    QgsMapLayer,
-    QgsVectorLayer,
-    QgsGeometryGeneratorSymbolLayer,
-    QgsFillSymbol,
-    QgsSingleSymbolRenderer,
-    QgsInvertedPolygonRenderer,
-    QgsGroupLayer,
-    QgsCoordinateTransformContext,
-    QgsMapThemeCollection,
-    QgsUnitTypes,
-)
+from qgis.core import (Qgis, QgsCoordinateTransformContext, QgsFillSymbol,
+                       QgsGeometryGeneratorSymbolLayer, QgsGroupLayer,
+                       QgsInvertedPolygonRenderer, QgsLayerTreeGroup,
+                       QgsMapLayer, QgsMapThemeCollection, QgsProject,
+                       QgsSingleSymbolRenderer, QgsUnitTypes, QgsVectorLayer)
 from qgis.gui import QgsMapCanvas
-from qgis.PyQt.QtGui import QPainter, QAction
+from qgis.PyQt.QtCore import QT_VERSION_STR
+from qgis.PyQt.QtGui import QAction, QPainter
 from qgis.PyQt.QtWidgets import QDockWidget
 from qgis.utils import iface
 
-from .constants import (
-    compare_mask_layer_name,
-    compare_group_name,
-    compare_background_layer_name,
-    horizontal_split_geometry,
-    vertical_split_geometry,
-    lens_geometry,
-    compare_background_geometry,
-    mirror_widget_name,
-    mirror_maptheme_name,
-)
-from .utils import (
-    is_in_group,
-    make_dynamic,
-    get_visible_layers,
-    toggle_layers,
-    get_map_dockwidgets,
-    get_right_dockwidgets,
-    set_panel_width,
-)
+from .constants import (compare_background_geometry,
+                        compare_background_layer_name, compare_group_name,
+                        compare_mask_layer_name, horizontal_split_geometry,
+                        lens_geometry, mirror_maptheme_name,
+                        mirror_widget_name, vertical_split_geometry)
+from .utils import (get_map_dockwidgets, get_right_dockwidgets,
+                    get_visible_layers, is_in_group, make_dynamic,
+                    set_panel_width, toggle_layers)
+
+QT_VERSION_INT = int(QT_VERSION_STR.split(".")[0])
+
+if QT_VERSION_INT <= 5:
+    dock_widget_floatable = QDockWidget.DockWidgetFloatable
+    dock_widget_movable = QDockWidget.DockWidgetMovable
+    composition_mode_destination_in = QPainter.CompositionMode_DestinationIn
+else:
+    dock_widget_floatable = QDockWidget.DockWidgetFeature.DockWidgetFloatable
+    dock_widget_movable = QDockWidget.DockWidgetFeature.DockWidgetMovable
+    composition_mode_destination_in = QPainter.CompositionMode.CompositionMode_DestinationIn
 
 # Syncronize flag to avoid recursive map sync and crash
 map_synchronizing = False
@@ -119,7 +110,7 @@ def compare_with_mask(compare_layers: list, compare_method: str) -> None:
     compare_mask_layer.setRenderer(inverted_renderer)
 
     # Change mask layer blend mode to fit with 'Invert Mask Below'
-    compare_mask_layer.setBlendMode(QPainter.CompositionMode_DestinationIn)
+    compare_mask_layer.setBlendMode(composition_mode_destination_in)
 
     # update compare mask layer rendering
     compare_mask_layer.triggerRepaint()
@@ -157,7 +148,7 @@ def _create_compare_layer_group_and_mask(
         if compare_method == "lens":
             make_dynamic(mask_layer)
         else:
-            mask_layer.setAutoRefreshEnabled(False)
+            mask_layer.setAutoRefreshMode(Qgis.AutoRefreshMode.Disabled)
     else:
         mask_layer = QgsVectorLayer(
             f"Polygon?crs={project.crs().authid()}", compare_mask_layer_name, "memory"
@@ -169,7 +160,7 @@ def _create_compare_layer_group_and_mask(
             if compare_method == "lens":
                 make_dynamic(mask_layer)
             else:
-                mask_layer.setAutoRefreshEnabled(False)
+                mask_layer.setAutoRefreshMode(Qgis.AutoRefreshMode.Disabled)
             # Add polygon layer to compare layer group
             project.addMapLayer(mask_layer, False)
 
@@ -226,7 +217,7 @@ def compare_with_mapview(compare_layers: list) -> None:
 
     # Don't show close button feature to avoid bug when closing mirror window
     mirror_dock_widget.setFeatures(
-        QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetMovable
+        dock_widget_floatable | dock_widget_movable
     )
 
     # Tabify right panels layouts Tabify with other Docks in right side
@@ -253,9 +244,9 @@ def compare_with_mapview(compare_layers: list) -> None:
         if mirror_dock_widget:
             main_window.tabifyDockWidget(base_dock, mirror_dock_widget)
 
-    else:
+    elif len(right_dock_widgets) == 1:
         # Case of if there is no other panel in right side
-        set_panel_width(right_dock_widgets[0], compare_map_size)
+        set_panel_width(right_dock_widgets[0], int(compare_map_size))
         mirror_widget.refresh()
 
     # Add Map themes

--- a/comparator/process.py
+++ b/comparator/process.py
@@ -1,22 +1,44 @@
-from qgis.core import (Qgis, QgsCoordinateTransformContext, QgsFillSymbol,
-                       QgsGeometryGeneratorSymbolLayer, QgsGroupLayer,
-                       QgsInvertedPolygonRenderer, QgsLayerTreeGroup,
-                       QgsMapLayer, QgsMapThemeCollection, QgsProject,
-                       QgsSingleSymbolRenderer, QgsUnitTypes, QgsVectorLayer)
+from qgis.core import (
+    Qgis,
+    QgsCoordinateTransformContext,
+    QgsFillSymbol,
+    QgsGeometryGeneratorSymbolLayer,
+    QgsGroupLayer,
+    QgsInvertedPolygonRenderer,
+    QgsLayerTreeGroup,
+    QgsMapLayer,
+    QgsMapThemeCollection,
+    QgsProject,
+    QgsSingleSymbolRenderer,
+    QgsUnitTypes,
+    QgsVectorLayer,
+)
 from qgis.gui import QgsMapCanvas
 from qgis.PyQt.QtCore import QT_VERSION_STR
 from qgis.PyQt.QtGui import QAction, QPainter
 from qgis.PyQt.QtWidgets import QDockWidget
 from qgis.utils import iface
 
-from .constants import (compare_background_geometry,
-                        compare_background_layer_name, compare_group_name,
-                        compare_mask_layer_name, horizontal_split_geometry,
-                        lens_geometry, mirror_maptheme_name,
-                        mirror_widget_name, vertical_split_geometry)
-from .utils import (get_map_dockwidgets, get_right_dockwidgets,
-                    get_visible_layers, is_in_group, make_dynamic,
-                    set_panel_width, toggle_layers)
+from .constants import (
+    compare_background_geometry,
+    compare_background_layer_name,
+    compare_group_name,
+    compare_mask_layer_name,
+    horizontal_split_geometry,
+    lens_geometry,
+    mirror_maptheme_name,
+    mirror_widget_name,
+    vertical_split_geometry,
+)
+from .utils import (
+    get_map_dockwidgets,
+    get_right_dockwidgets,
+    get_visible_layers,
+    is_in_group,
+    make_dynamic,
+    set_panel_width,
+    toggle_layers,
+)
 
 QT_VERSION_INT = int(QT_VERSION_STR.split(".")[0])
 
@@ -27,7 +49,9 @@ if QT_VERSION_INT <= 5:
 else:
     dock_widget_floatable = QDockWidget.DockWidgetFeature.DockWidgetFloatable
     dock_widget_movable = QDockWidget.DockWidgetFeature.DockWidgetMovable
-    composition_mode_destination_in = QPainter.CompositionMode.CompositionMode_DestinationIn
+    composition_mode_destination_in = (
+        QPainter.CompositionMode.CompositionMode_DestinationIn
+    )
 
 # Syncronize flag to avoid recursive map sync and crash
 map_synchronizing = False
@@ -216,9 +240,7 @@ def compare_with_mapview(compare_layers: list) -> None:
     mirror_dock_widget.setWindowTitle(mirror_widget_name)
 
     # Don't show close button feature to avoid bug when closing mirror window
-    mirror_dock_widget.setFeatures(
-        dock_widget_floatable | dock_widget_movable
-    )
+    mirror_dock_widget.setFeatures(dock_widget_floatable | dock_widget_movable)
 
     # Tabify right panels layouts Tabify with other Docks in right side
     right_dock_widgets = get_right_dockwidgets()

--- a/comparator/utils.py
+++ b/comparator/utils.py
@@ -1,19 +1,18 @@
-from qgis.core import (
-    Qgis,
-    QgsMapLayer,
-    QgsLayerTreeGroup,
-    QgsProject,
-    QgsLayerTreeLayer,
-)
-
+from qgis.core import (Qgis, QgsLayerTreeGroup, QgsLayerTreeLayer, QgsMapLayer,
+                       QgsProject)
 from qgis.gui import QgsMapCanvas
-
+from qgis.PyQt.QtCore import QT_VERSION_STR, Qt
 from qgis.PyQt.QtWidgets import QDockWidget
 from qgis.utils import iface
-from qgis.PyQt.QtCore import Qt
 
 from .constants import lens_auto_refresh_interval_time
 
+QT_VERSION_INT = int(QT_VERSION_STR.split(".")[0])
+
+if QT_VERSION_INT <= 5:
+    right_dock_widget_area = Qt.RightDockWidgetArea
+else:
+    right_dock_widget_area = Qt.DockWidgetArea.RightDockWidgetArea
 
 def is_in_group(layer: QgsMapLayer, layer_group: QgsLayerTreeGroup) -> bool:
     """
@@ -30,7 +29,6 @@ def make_dynamic(layer: QgsMapLayer) -> None:
     make layer dynamic by refreshing with interval
     interval is set with lens_auto_refresh_interval_time in ms
     """
-    layer.setAutoRefreshEnabled(True)
     layer.setAutoRefreshInterval(lens_auto_refresh_interval_time)
     layer.setAutoRefreshMode(Qgis.AutoRefreshMode.ReloadData)
 
@@ -91,7 +89,7 @@ def get_right_dockwidgets() -> list:
     for dock in main_window.findChildren(QDockWidget):
         # Check which side (dock area) the widget is in
         dock_area = main_window.dockWidgetArea(dock)
-        if dock_area == Qt.RightDockWidgetArea and dock.isVisible():
+        if dock_area == right_dock_widget_area and dock.isVisible():
             right_dock_widgets.append(dock)
 
     return right_dock_widgets

--- a/comparator/utils.py
+++ b/comparator/utils.py
@@ -1,5 +1,10 @@
-from qgis.core import (Qgis, QgsLayerTreeGroup, QgsLayerTreeLayer, QgsMapLayer,
-                       QgsProject)
+from qgis.core import (
+    Qgis,
+    QgsLayerTreeGroup,
+    QgsLayerTreeLayer,
+    QgsMapLayer,
+    QgsProject,
+)
 from qgis.gui import QgsMapCanvas
 from qgis.PyQt.QtCore import QT_VERSION_STR, Qt
 from qgis.PyQt.QtWidgets import QDockWidget
@@ -13,6 +18,7 @@ if QT_VERSION_INT <= 5:
     right_dock_widget_area = Qt.RightDockWidgetArea
 else:
     right_dock_widget_area = Qt.DockWidgetArea.RightDockWidgetArea
+
 
 def is_in_group(layer: QgsMapLayer, layer_group: QgsLayerTreeGroup) -> bool:
     """

--- a/metadata.txt
+++ b/metadata.txt
@@ -1,6 +1,7 @@
 [general]
 name=QMapCompare
 qgisMinimumVersion=3.34
+supportsQt6=True
 about=Select layers and visualize comparison in mirror, split and lens mode.
 description=A QGIS plugin that enables you to compare maps smoothly.
 version={{PLUGIN_VERSION}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "qgis-plugin-template"
 version = "0.1.0"
-description = "Add your description here"
+description = "A QGIS plugin that enables you to compare maps smoothly."
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = []

--- a/qmapcompare.py
+++ b/qmapcompare.py
@@ -1,10 +1,17 @@
 import os
 
-from PyQt5.QtWidgets import QAction
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QT_VERSION_STR, Qt
 from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QAction
 
 from .qmapcompare_dockwidget import QMapCompareDockWidget
+
+QT_VERSION_INT = int(QT_VERSION_STR.split(".")[0])
+
+if QT_VERSION_INT <= 5:
+    left_dock_widget_area = Qt.LeftDockWidgetArea
+else:
+    left_dock_widget_area = Qt.DockWidgetArea.LeftDockWidgetArea
 
 PLUGIN_NAME = "QMapCompare"
 
@@ -64,7 +71,7 @@ class QMapCompare:
 
         # Add UI to panel
         self.dockwidget = QMapCompareDockWidget()
-        self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.dockwidget)
+        self.iface.addDockWidget(left_dock_widget_area, self.dockwidget)
         # Populate layers in UI
         self.dockwidget.process_node()
 
@@ -85,5 +92,5 @@ class QMapCompare:
             self.dockwidget.hide()
         else:
             self.dockwidget.show()
-            self.iface.addDockWidget(Qt.LeftDockWidgetArea, self.dockwidget)
+            self.iface.addDockWidget(left_dock_widget_area, self.dockwidget)
             self.dockwidget.process_node()

--- a/qmapcompare_dockwidget.py
+++ b/qmapcompare_dockwidget.py
@@ -1,26 +1,15 @@
 import os
-import sip
 
-from PyQt5.QtWidgets import QDockWidget, QMessageBox, QTreeWidgetItem
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
-from qgis.PyQt import uic
-from qgis.core import (
-    QgsProject,
-    QgsLayerTree,
-    QgsLayerTreeGroup,
-    QgsLayerTreeLayer,
-    QgsApplication,
-    QgsMapLayerModel,
-)
+from qgis.core import (QgsApplication, QgsLayerTree, QgsLayerTreeGroup,
+                       QgsLayerTreeLayer, QgsMapLayerModel, QgsProject)
+from qgis.PyQt import sip, uic
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QIcon
+from qgis.PyQt.QtWidgets import QDockWidget, QMessageBox, QTreeWidgetItem
 
-from .comparator.process import (
-    compare_with_mask,
-    compare_with_mapview,
-    stop_compare_with_mask,
-    stop_mirror_compare,
-)
 from .comparator.constants import compare_group_name
+from .comparator.process import (compare_with_mapview, compare_with_mask,
+                                 stop_compare_with_mask, stop_mirror_compare)
 
 
 class QMapCompareDockWidget(QDockWidget):

--- a/qmapcompare_dockwidget.py
+++ b/qmapcompare_dockwidget.py
@@ -1,15 +1,25 @@
 import os
 
-from qgis.core import (QgsApplication, QgsLayerTree, QgsLayerTreeGroup,
-                       QgsLayerTreeLayer, QgsMapLayerModel, QgsProject)
+from qgis.core import (
+    QgsApplication,
+    QgsLayerTree,
+    QgsLayerTreeGroup,
+    QgsLayerTreeLayer,
+    QgsMapLayerModel,
+    QgsProject,
+)
 from qgis.PyQt import sip, uic
 from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QDockWidget, QMessageBox, QTreeWidgetItem
 
 from .comparator.constants import compare_group_name
-from .comparator.process import (compare_with_mapview, compare_with_mask,
-                                 stop_compare_with_mask, stop_mirror_compare)
+from .comparator.process import (
+    compare_with_mapview,
+    compare_with_mask,
+    stop_compare_with_mask,
+    stop_mirror_compare,
+)
 
 
 class QMapCompareDockWidget(QDockWidget):


### PR DESCRIPTION
### What I did（変更内容）
<!-- Please describe the motivation behind this PR and the changes it introduces. -->
<!-- どのような変更をしますか？ 目的は？ -->

- Support Qt6
- replace a duplicated method
- bugfix for index error on right_dock_widgets


### Notes（連絡事項）
<!-- If manual testing is required, please describe the procedure. -->
<!-- 手動での動作確認が必要なら手順を簡単に伝えてください。そのほか連絡事項など。 -->

- Tested following environments:
  - Windows:
    - 3.42.1 (Qt5 and Qt6)
  - Mac
    - Master ([Qt6 Mac build](https://github.com/qgis/QGIS/pull/60039))
    - 3.42.1 (Qt5)
  - Linux
    - 3.42.1 (Qt5, conda-forge)
- Test runner docker image for Qt6 build is not available now.
