### PR TITLE
Fix `compare_map_size` type bug

### DIFF
--- a/comparator/process.py
+++ b/comparator/process.py
@@ -237,7 +237,7 @@ def compare_with_mapview(compare_layers: list) -> None:
         max_width = max(dw.geometry().width() for dw in right_dock_widgets)
     else:
         max_width = 0
-    compare_map_size = (iface.mapCanvas().size().width() + max_width) / 2
+    compare_map_size = int((iface.mapCanvas().size().width() + max_width) / 2)
 
     # Do only if there are more than 1 dock widget (1 is mirror compare map panel)
     if len(right_dock_widgets) > 1:
@@ -245,7 +245,7 @@ def compare_with_mapview(compare_layers: list) -> None:
         for i in range(1, len(right_dock_widgets)):
             if right_dock_widgets[i].windowTitle() == mirror_widget_name:
                 mirror_dock_widget = right_dock_widgets[i]
-                set_panel_width(mirror_dock_widget, int(compare_map_size))
+                set_panel_width(mirror_dock_widget, compare_map_size)
             else:
                 main_window.tabifyDockWidget(base_dock, right_dock_widgets[i])
 


### PR DESCRIPTION

### What I did（変更内容）

I restricted the type of `compare_map_size` to `int`.

At the following line:

https://github.com/MIERUNE/qgis-plugin-qmapcompare/blob/dd840842daad6cc891e3371f66f135245d78448f/comparator/process.py#L240

there is a possibility that `compare_map_size` could become a float.

If that happens, it will cause an error at:

https://github.com/MIERUNE/qgis-plugin-qmapcompare/blob/dd840842daad6cc891e3371f66f135245d78448f/comparator/process.py#L258

Although we could cast `compare_map_size` to `int` just before using it, since it represents a screen size, I decided to define it as an `int` from the beginning.


### Notes（連絡事項）


The following error occurs during execution, which breaks the rendering:

```
Pythonコードの実行中にエラーが発生しました: 

TypeError: setFixedWidth(self, w: int): argument 1 has unexpected type 'float' 
Traceback (most recent call last):
  File "C:\Users/meltingrabbit/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qmapcompare\qmapcompare_dockwidget.py", line 170, in _on_pushbutton_mirror_clicked
    compare_with_mapview(layers)
  File "C:\Users/meltingrabbit/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qmapcompare\comparator\process.py", line 258, in compare_with_mapview
    set_panel_width(right_dock_widgets[0], compare_map_size)
  File "C:\Users/meltingrabbit/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\qmapcompare\comparator\utils.py", line 102, in set_panel_width
    widget.setFixedWidth(size)
TypeError: setFixedWidth(self, w: int): argument 1 has unexpected type 'float'


Pythonバージョン: 3.12.3 (main, Apr 14 2024, 17:21:43) [MSC v.1938 64 bit (AMD64)] 
QGISバージョン: 3.34.7-Prizren Prizren, 6f7d735c 

Pythonパス:
C:/PROGRA~1/QGIS33~1.7/apps/qgis-ltr/./python
C:/Users/meltingrabbit/AppData/Roaming/QGIS/QGIS3\profiles\default/python
C:/Users/meltingrabbit/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins
C:/PROGRA~1/QGIS33~1.7/apps/qgis-ltr/./python/plugins
C:\PROGRA~1\QGIS33~1.7\apps\grass\grass83\etc\python
C:\hoge\qgis
C:\PROGRA~1\QGIS33~1.7\bin\python312.zip
C:\PROGRA~1\QGIS33~1.7\apps\Python312\DLLs
C:\PROGRA~1\QGIS33~1.7\apps\Python312\Lib
C:\PROGRA~1\QGIS33~1.7\bin
C:\PROGRA~1\QGIS33~1.7\apps\Python312
C:\PROGRA~1\QGIS33~1.7\apps\Python312\Lib\site-packages
C:\PROGRA~1\QGIS33~1.7\apps\Python312\Lib\site-packages\win32
C:\PROGRA~1\QGIS33~1.7\apps\Python312\Lib\site-packages\win32\lib
C:\PROGRA~1\QGIS33~1.7\apps\Python312\Lib\site-packages\Pythonwin
C:/Users/meltingrabbit/AppData/Roaming/QGIS/QGIS3\profiles\default/python
C:/hoge/qgis
```

In my case, this occurred frequently when using mirror split mode, and one side of the screen stopped following the movement of the other side.
