### PR TITLE
Fix PyQt5 direct import for QGIS 4.0 compatibility

### DIFF
--- a/tests/qgis_interface.py
+++ b/tests/qgis_interface.py
@@ -26,7 +26,7 @@ __copyright__ = (
 
 from typing import List
 
-from PyQt5.QtCore import QObject, QSize, pyqtSignal, pyqtSlot
+from qgis.PyQt.QtCore import QObject, QSize, pyqtSignal, pyqtSlot
 from qgis.core import QgsMapLayer, QgsProject
 from qgis.gui import QgsMapCanvas, QgsMessageBar
 from qgis.PyQt.QtWidgets import QDockWidget


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #49 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

Replace direct PyQt5 import with `qgis.PyQt` import in `tests/qgis_interface.py` to ensure QGIS 4.0 (Qt6) compatibility.

**Before:**
```python
from PyQt5.QtCore import QObject, QSize, pyqtSignal, pyqtSlot
```

**After:**
```python
from qgis.PyQt.QtCore import QObject, QSize, pyqtSignal, pyqtSlot
```

### Notes
<!-- If manual testing is required, please describe the procedure. -->
