### PR TITLE
Add lens shape and size settings for compare mode

### DIFF
--- a/comparator/constants.py
+++ b/comparator/constants.py
@@ -23,7 +23,10 @@ horizontal_split_geometry = """make_rectangle_3points(
         make_point(x(@map_extent_center) - (@map_extent_width / 2), y(@map_extent_center) - (@map_extent_height / 2)),
         0)"""
 
-def get_lens_geometry(shape: str = "circle", rate: float = lens_default_size_rate) -> str:
+
+def get_lens_geometry(
+    shape: str = "circle", rate: float = lens_default_size_rate
+) -> str:
     """Generate lens geometry expression for the given shape and size rate."""
     rate = max(lens_min_size_rate, min(lens_max_size_rate, rate))
     if shape == "square":
@@ -35,6 +38,7 @@ def get_lens_geometry(shape: str = "circle", rate: float = lens_default_size_rat
         top_right = f"make_point({cx} + {offset}, {cy} + {offset})"
         return f"make_rectangle_3points({bottom_left}, {top_left}, {top_right}, 0)"
     return f"buffer(@canvas_cursor_point, @map_extent_width * {rate})"
+
 
 compare_background_geometry = """@map_extent"""
 

--- a/comparator/constants.py
+++ b/comparator/constants.py
@@ -4,8 +4,9 @@ compare_mask_layer_name = "QMapCompareMask"
 compare_background_layer_name = "QMapCompareBackground"
 
 # Lens compare parameters
-# - lens radius is 15% of the map extent width
-lens_size_rate_from_map_canvas = 0.15
+lens_default_size_rate = 0.15
+lens_min_size_rate = 0.05
+lens_max_size_rate = 0.40
 # - lens dynamic refresh interval: 200 milliseconds = 0.2s
 lens_auto_refresh_interval_time = 200
 
@@ -22,7 +23,18 @@ horizontal_split_geometry = """make_rectangle_3points(
         make_point(x(@map_extent_center) - (@map_extent_width / 2), y(@map_extent_center) - (@map_extent_height / 2)),
         0)"""
 
-lens_geometry = f"buffer(@canvas_cursor_point, @map_extent_width * {lens_size_rate_from_map_canvas})"
+def get_lens_geometry(shape: str = "circle", rate: float = lens_default_size_rate) -> str:
+    """Generate lens geometry expression for the given shape and size rate."""
+    rate = max(lens_min_size_rate, min(lens_max_size_rate, rate))
+    if shape == "square":
+        cx = "x(@canvas_cursor_point)"
+        cy = "y(@canvas_cursor_point)"
+        offset = f"@map_extent_width * {rate}"
+        bottom_left = f"make_point({cx} - {offset}, {cy} - {offset})"
+        top_left = f"make_point({cx} - {offset}, {cy} + {offset})"
+        top_right = f"make_point({cx} + {offset}, {cy} + {offset})"
+        return f"make_rectangle_3points({bottom_left}, {top_left}, {top_right}, 0)"
+    return f"buffer(@canvas_cursor_point, @map_extent_width * {rate})"
 
 compare_background_geometry = """@map_extent"""
 

--- a/comparator/process.py
+++ b/comparator/process.py
@@ -24,8 +24,9 @@ from .constants import (
     compare_background_layer_name,
     compare_group_name,
     compare_mask_layer_name,
+    get_lens_geometry,
     horizontal_split_geometry,
-    lens_geometry,
+    lens_default_size_rate,
     mirror_maptheme_name,
     mirror_widget_name,
     vertical_split_geometry,
@@ -57,7 +58,12 @@ else:
 map_synchronizing = False
 
 
-def compare_with_mask(compare_layers: list, compare_method: str) -> None:
+def compare_with_mask(
+    compare_layers: list,
+    compare_method: str,
+    lens_shape: str = "circle",
+    lens_size_rate: float = lens_default_size_rate,
+) -> None:
     """
     Make QGIS Map to be in compare mode with mask layer group method
     with input compare layers
@@ -114,7 +120,7 @@ def compare_with_mask(compare_layers: list, compare_method: str) -> None:
     if compare_method == "horizontal":
         geometry_formula = horizontal_split_geometry
     if compare_method == "lens":
-        geometry_formula = lens_geometry
+        geometry_formula = get_lens_geometry(lens_shape, lens_size_rate)
 
     geometry_generator = QgsGeometryGeneratorSymbolLayer.create(
         {

--- a/qmapcompare_dockwidget.py
+++ b/qmapcompare_dockwidget.py
@@ -70,15 +70,11 @@ class QMapCompareDockWidget(QDockWidget):
         self.ui.label_lens_size_value.setText(f"{int(lens_default_size_rate * 100)}%")
 
         # Lens settings signals
-        self.ui.slider_lens_size.sliderReleased.connect(
-            self._on_lens_settings_changed
-        )
+        self.ui.slider_lens_size.sliderReleased.connect(self._on_lens_settings_changed)
         self.ui.comboBox_lens_shape.currentIndexChanged.connect(
             self._on_lens_settings_changed
         )
-        self.ui.slider_lens_size.valueChanged.connect(
-            self._on_lens_size_value_changed
-        )
+        self.ui.slider_lens_size.valueChanged.connect(self._on_lens_size_value_changed)
 
         # Populate layer tree box when open a project
         QgsProject.instance().readProject.connect(self.process_node)

--- a/qmapcompare_dockwidget.py
+++ b/qmapcompare_dockwidget.py
@@ -340,6 +340,8 @@ class QMapCompareDockWidget(QDockWidget):
 
     def _on_lens_size_value_changed(self, value: int) -> None:
         self.ui.label_lens_size_value.setText(f"{value}%")
+        if not self.ui.slider_lens_size.isSliderDown():
+            self._on_lens_settings_changed()
 
     def _on_lens_settings_changed(self):
         """Reapply lens compare when lens settings are changed."""

--- a/qmapcompare_dockwidget.py
+++ b/qmapcompare_dockwidget.py
@@ -13,7 +13,12 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QDockWidget, QMessageBox, QTreeWidgetItem
 
-from .comparator.constants import compare_group_name
+from .comparator.constants import (
+    compare_group_name,
+    lens_default_size_rate,
+    lens_max_size_rate,
+    lens_min_size_rate,
+)
 from .comparator.process import (
     compare_with_mapview,
     compare_with_mask,
@@ -58,6 +63,23 @@ class QMapCompareDockWidget(QDockWidget):
             self._on_pushbutton_stopcompare_clicked
         )
 
+        # Initialize lens settings from constants
+        self.ui.slider_lens_size.setMinimum(int(lens_min_size_rate * 100))
+        self.ui.slider_lens_size.setMaximum(int(lens_max_size_rate * 100))
+        self.ui.slider_lens_size.setValue(int(lens_default_size_rate * 100))
+        self.ui.label_lens_size_value.setText(f"{int(lens_default_size_rate * 100)}%")
+
+        # Lens settings signals
+        self.ui.slider_lens_size.sliderReleased.connect(
+            self._on_lens_settings_changed
+        )
+        self.ui.comboBox_lens_shape.currentIndexChanged.connect(
+            self._on_lens_settings_changed
+        )
+        self.ui.slider_lens_size.valueChanged.connect(
+            self._on_lens_size_value_changed
+        )
+
         # Populate layer tree box when open a project
         QgsProject.instance().readProject.connect(self.process_node)
 
@@ -88,6 +110,7 @@ class QMapCompareDockWidget(QDockWidget):
             self.ui.pushButton_v_split.setEnabled(True)
             self.ui.pushButton_lens.setEnabled(True)
             self.ui.pushButton_mirror.setEnabled(True)
+            self.ui.groupBox_lens_settings.setVisible(False)
 
             if self.active_compare_mode == "mirror":
                 stop_mirror_compare()
@@ -113,6 +136,7 @@ class QMapCompareDockWidget(QDockWidget):
             self.ui.pushButton_h_split.setEnabled(True)
             self.ui.pushButton_lens.setEnabled(True)
             self.ui.pushButton_mirror.setEnabled(True)
+            self.ui.groupBox_lens_settings.setVisible(False)
 
             if self.active_compare_mode == "mirror":
                 stop_mirror_compare()
@@ -138,6 +162,7 @@ class QMapCompareDockWidget(QDockWidget):
             self.ui.pushButton_v_split.setEnabled(True)
             self.ui.pushButton_lens.setEnabled(False)
             self.ui.pushButton_mirror.setEnabled(True)
+            self.ui.groupBox_lens_settings.setVisible(True)
 
             if self.active_compare_mode == "mirror":
                 stop_mirror_compare()
@@ -147,7 +172,12 @@ class QMapCompareDockWidget(QDockWidget):
             self._memorize_checked_layers(layers)
 
             self.is_processing = True
-            compare_with_mask(layers, "lens")
+            compare_with_mask(
+                layers,
+                "lens",
+                lens_shape=self._get_lens_shape(),
+                lens_size_rate=self._get_lens_size_rate(),
+            )
             self.is_processing = False
         else:
             QMessageBox.information(
@@ -163,6 +193,7 @@ class QMapCompareDockWidget(QDockWidget):
             self.ui.pushButton_v_split.setEnabled(True)
             self.ui.pushButton_lens.setEnabled(True)
             self.ui.pushButton_mirror.setEnabled(False)
+            self.ui.groupBox_lens_settings.setVisible(False)
 
             # Stop compare to remove mask group layer
             if self.active_compare_mode in ["hsplit", "vsplit", "lens"]:
@@ -193,6 +224,7 @@ class QMapCompareDockWidget(QDockWidget):
         self.ui.pushButton_v_split.setEnabled(True)
         self.ui.pushButton_lens.setEnabled(True)
         self.ui.pushButton_mirror.setEnabled(True)
+        self.ui.groupBox_lens_settings.setVisible(False)
 
         self.active_compare_mode = "inactive"
 
@@ -302,6 +334,32 @@ class QMapCompareDockWidget(QDockWidget):
             if child_type == "group" and child.name() != compare_group_name:
                 self._process_node_recursive(child, item)
 
+    def _get_lens_size_rate(self) -> float:
+        return self.ui.slider_lens_size.value() / 100.0
+
+    def _get_lens_shape(self) -> str:
+        if self.ui.comboBox_lens_shape.currentIndex() == 1:
+            return "square"
+        return "circle"
+
+    def _on_lens_size_value_changed(self, value: int) -> None:
+        self.ui.label_lens_size_value.setText(f"{value}%")
+
+    def _on_lens_settings_changed(self):
+        """Reapply lens compare when lens settings are changed."""
+        if self.active_compare_mode != "lens":
+            return
+        layers = self._get_checked_layers()
+        if layers:
+            self.is_processing = True
+            compare_with_mask(
+                layers,
+                "lens",
+                lens_shape=self._get_lens_shape(),
+                lens_size_rate=self._get_lens_size_rate(),
+            )
+            self.is_processing = False
+
     def _memorize_checked_layers(self, layers):
         self.checked_layers = []
         for layer in layers:
@@ -321,7 +379,12 @@ class QMapCompareDockWidget(QDockWidget):
             if self.active_compare_mode == "hsplit":
                 compare_with_mask(layers, "horizontal")
             if self.active_compare_mode == "lens":
-                compare_with_mask(layers, "lens")
+                compare_with_mask(
+                    layers,
+                    "lens",
+                    lens_shape=self._get_lens_shape(),
+                    lens_size_rate=self._get_lens_size_rate(),
+                )
             if self.active_compare_mode == "mirror":
                 compare_with_mapview(layers)
 

--- a/qmapcompare_dockwidget.ui
+++ b/qmapcompare_dockwidget.ui
@@ -159,6 +159,68 @@
       </layout>
      </item>
      <item>
+      <widget class="QGroupBox" name="groupBox_lens_settings">
+       <property name="title">
+        <string>Lens Settings</string>
+       </property>
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_lens">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_shape">
+          <item>
+           <widget class="QLabel" name="label_shape">
+            <property name="text">
+             <string>Shape:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboBox_lens_shape">
+            <item>
+             <property name="text">
+              <string>Circle</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Square</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_size">
+          <item>
+           <widget class="QLabel" name="label_size">
+            <property name="text">
+             <string>Size:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSlider" name="slider_lens_size">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_lens_size_value">
+            <property name="text">
+             <string></string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="pushButton_stopcompare">
        <property name="text">
         <string>Stop</string>


### PR DESCRIPTION
<!-- Close or Related Issues -->
Close #44 
Close #45 

### What I did
<!-- Please describe the motivation behind this PR and the changes it introduces. -->

- Add circle/square shape selection for lens compare mode
- Add slider control to adjust lens size (5%-40%)
- Show lens settings panel only when lens mode is active
- Apply settings changes in real-time without restarting compare

### Notes
<!-- If manual testing is required, please describe the procedure. -->

![sample2](https://github.com/user-attachments/assets/69f8e5e6-e7f3-4ff4-ada8-2c7ef86a3b32)

![sample1](https://github.com/user-attachments/assets/dc4644d0-faf7-4290-b81e-cfa874f07765)
